### PR TITLE
Fix task output dependency issues for jacoco

### DIFF
--- a/jacoco/src/main/kotlin/org/projectnessie/buildtools/jacoco/JacocoHelperPlugin.kt
+++ b/jacoco/src/main/kotlin/org/projectnessie/buildtools/jacoco/JacocoHelperPlugin.kt
@@ -94,9 +94,15 @@ class JacocoHelperPlugin : Plugin<Project> {
         attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
       }
       val sourceSets = project.extensions.getByType<JavaPluginExtension>().sourceSets
-      val mainSourceSet = sourceSets.named("main").get()
+      val mainSourceSet = sourceSets.getByName("main")
       mainSourceSet.java.srcDirs.forEach {
         outgoing.artifact(it) { builtBy(tasks.named(mainSourceSet.classesTaskName)) }
+      }
+      val quarkusGeneratedSourceSet = sourceSets.findByName("quarkus-generated-sources")
+      if (quarkusGeneratedSourceSet != null) {
+        quarkusGeneratedSourceSet.java.srcDirs.forEach {
+          outgoing.artifact(it) { builtBy(tasks.named(quarkusGeneratedSourceSet.classesTaskName)) }
+        }
       }
     }
 
@@ -111,9 +117,15 @@ class JacocoHelperPlugin : Plugin<Project> {
         attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("class-folders"))
       }
       val sourceSets = project.extensions.getByType<JavaPluginExtension>().sourceSets
-      val mainSourceSet = sourceSets.named("main").get()
+      val mainSourceSet = sourceSets.getByName("main")
       outgoing.artifact(mainSourceSet.java.destinationDirectory) {
         builtBy(tasks.named(mainSourceSet.classesTaskName))
+      }
+      val quarkusGeneratedSourceSet = sourceSets.findByName("quarkus-generated-sources")
+      if (quarkusGeneratedSourceSet != null) {
+        outgoing.artifact(quarkusGeneratedSourceSet.java.destinationDirectory) {
+          builtBy(tasks.named(quarkusGeneratedSourceSet.classesTaskName))
+        }
       }
     }
 


### PR DESCRIPTION
Example:
```
> Task :code-coverage:codeCoverageReport
Execution optimizations have been disabled for task ':code-coverage:codeCoverageReport' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/avdl'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/avpr'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/avsc'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/snazy/devel/projectnessie/nessie/nessie/servers/lambda/build/classes/java/quarkus-generated-sources/grpc'. Reason: Task ':code-coverage:codeCoverageReport' uses this output of task ':servers:lambda:compileQuarkusGeneratedSourcesJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```