### PR TITLE
Do not publish to plugins.gradle.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,6 @@ jobs:
             check 
             publishToSonatype 
             closeAndReleaseSonatypeStagingRepository 
-            publishPlugins
-            -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
-            -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
             -Prelease
 
       - name: Bump to next development version


### PR DESCRIPTION
The plugins in the `gradle-build-plugins`repository are rather "private" build plugins for projectnessie, not generally useful plugins yet. We might consider some of to be documented and refactored for general usage.