### PR TITLE
Remove Gradle type-safe project accessors

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -103,5 +103,3 @@ include("spotless")
 if (false) {
   include("gradle:dependabot")
 }
-
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Prerequisite for integrations and tools testing framework, which uses
Gradle's `includeBuild` functionality. Gradle type-safe project
accessors requires that project names must not contain dot characters,
but Iceberg project names _do_ use dot characters. Refactoring the
Iceberg build is not really an option.

It's a bit sad that it's necessary that we cannot use Gradle's
type-safe accessors.