### PR TITLE
errorprone: keep default severity of checks

### DIFF
--- a/errorprone/src/main/kotlin/org/projectnessie/buildtools/errorprone/ErrorproneHelperPlugin.kt
+++ b/errorprone/src/main/kotlin/org/projectnessie/buildtools/errorprone/ErrorproneHelperPlugin.kt
@@ -39,7 +39,6 @@ class ErrorproneHelperPlugin : Plugin<Project> {
     project.run {
       apply<ErrorPronePlugin>()
       tasks.withType<JavaCompile>().configureEach {
-        options.errorprone.allErrorsAsWarnings.set(true)
         options.errorprone.disableWarningsInGeneratedCode.set(true)
 
         val errorproneRules =


### PR DESCRIPTION
from my experience the errorprone team is quite conservative as to what checks have ERROR severity by default.
they are usually bugs with low/no false positives.

we should use the errorprone plugin in this repo to enforce minimal standards for all projects in the projectnessie org, and thus we should at least default to the default errorprone strictness.
one could argue that we should be even stricter in that we raise the severity of some checks from WARNING to ERROR since we believe it will help find bugs and clear up ambiguous code (which from my experience is usually the case, because again, the errorprone team seems quite conservative in that regard).

if some of the projects will have problems with this new strictness we can either fix all newly found violations or let them opt out of the ERROR severity again by setting the `codestyle/errorprone-rules.properties` file.
but being strict by default is better imo.