### PR TITLE
Fixup `gradle.plugin` group-ID prefix for shadow plugin + bump to 8.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ val versionErrorPronePlugin = "3.0.1"
 val versionIdeaExtPlugin = dependencyVersion("versionIdeaExtPlugin")
 val versionJandex = "3.0.5"
 val versionJandexPlugin = "1.86"
-val versionShadowPlugin = "8.0.0"
+val versionShadowPlugin = "8.1.0"
 val versionSpotlessPlugin = dependencyVersion("versionSpotlessPlugin")
 
 mapOf(
@@ -48,7 +48,7 @@ dependencies {
   constraints {
     api("com.diffplug.spotless:spotless-plugin-gradle:$versionSpotlessPlugin")
     api("com.github.vlsi.gradle:jandex-plugin:$versionJandexPlugin")
-    api("gradle.plugin.com.github.johnrengelman:shadow:$versionShadowPlugin")
+    api("com.github.johnrengelman:shadow:$versionShadowPlugin")
     api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:$versionIdeaExtPlugin")
     api("net.ltgt.gradle:gradle-errorprone-plugin:$versionErrorPronePlugin")
     api("org.jboss:jandex:$versionJandex")

--- a/publishing/build.gradle.kts
+++ b/publishing/build.gradle.kts
@@ -20,9 +20,7 @@ plugins {
 }
 
 dependencies {
-  implementation(
-    "gradle.plugin.com.github.johnrengelman:shadow:${dependencyVersion("versionShadowPlugin")}"
-  )
+  implementation("com.github.johnrengelman:shadow:${dependencyVersion("versionShadowPlugin")}")
 }
 
 gradlePlugin {


### PR DESCRIPTION
Old versions of the plugin-publishing plugin published to Gradle's repository by prefixing every group-ID with `gradle.plugin` - that behavior's been removed. The shadow plugin's the first "candidate" hitting this.