### PR TITLE
Unignore gradle-wrapper.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ out/
 # gradle
 .gradle/
 build/
-gradle/wrapper/gradle-wrapper.jar
+!gradle-wrapper.jar


### PR DESCRIPTION
Since gradle-wrapper.jar is in Git, it should be actively tracked as well.