### PR TITLE
Reflection-config plugin: Ability to deal with relocated classes

### DIFF
--- a/reflection-config/src/main/kotlin/org/projectnessie/buildtools/reflectionconfig/ReflectionConfigExtension.kt
+++ b/reflection-config/src/main/kotlin/org/projectnessie/buildtools/reflectionconfig/ReflectionConfigExtension.kt
@@ -16,7 +16,8 @@
 
 package org.projectnessie.buildtools.reflectionconfig
 
-import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 
 /**
  * Configuration that specifies which classes shall be mentioned in generated reflection-config.json
@@ -32,21 +33,30 @@ import org.gradle.api.Project
  * Note that the plugin scans the classes using "asm" and does not consider any indirect superclass
  * nor does it consider any implicitly implementated interface.
  */
-open class ReflectionConfigExtension(project: Project) {
+interface ReflectionConfigExtension {
   /**
    * A superclass must match one of these regular expressions. If this list is empty, all
    * superclasses will match.
    */
-  val classExtendsPatterns = project.objects.listProperty(String::class.java)
+  val classExtendsPatterns: ListProperty<String>
 
   /**
    * Directly implemented interfaces must match one of these regular expressions. If this list is
    * empty, the class' directly implemented interfaces are not considered.
    */
-  val classImplementsPatterns = project.objects.listProperty(String::class.java)
+  val classImplementsPatterns: ListProperty<String>
 
   /**
    * Resolvable configuration(s) that should be scanned for classes matching the patterns as well.
    */
-  val includeConfigurations = project.objects.listProperty(String::class.java)
+  val includeConfigurations: ListProperty<String>
+
+  /**
+   * Defines a map of regex patterns and replacements to mutate the class name that appears in the
+   * generated `reflection-config.json`.
+   *
+   * When the class relocations, for example via the shadow Gradle plugin, happen, the generated
+   * `reflection-config.json` should also reference the relocated class names.
+   */
+  val relocations: MapProperty<String, String>
 }

--- a/reflection-config/src/main/kotlin/org/projectnessie/buildtools/reflectionconfig/ReflectionConfigPlugin.kt
+++ b/reflection-config/src/main/kotlin/org/projectnessie/buildtools/reflectionconfig/ReflectionConfigPlugin.kt
@@ -31,7 +31,7 @@ class ReflectionConfigPlugin : Plugin<Project> {
     project.run {
       plugins.apply(JavaLibraryPlugin::class.java)
 
-      extensions.create("reflectionConfig", ReflectionConfigExtension::class.java, this)
+      extensions.create("reflectionConfig", ReflectionConfigExtension::class.java)
 
       configureFor(SourceSet.MAIN_SOURCE_SET_NAME, this)
       configureFor(SourceSet.TEST_SOURCE_SET_NAME, this)
@@ -59,6 +59,7 @@ class ReflectionConfigPlugin : Plugin<Project> {
           classExtendsPatterns.set(e.classExtendsPatterns)
           classImplementsPatterns.set(e.classImplementsPatterns)
           includeConfigurations.set(e.includeConfigurations)
+          relocations.set(e.relocations)
 
           dependsOn(compileJava)
         }


### PR DESCRIPTION
When a project's classes are (later) relocated, for example via the shadow plugin, the generated `reflection-config.json` should also reference the relocated class names.

It is quite tricky, and actually subject to the Shadow plugin's internals, to inquire the relocated class name for a "source" class name. It would also make the reflection-config plugin depend on the shadow plugin and potentially cause plugin class path issues in Gradle.

The solution here is to provide a map of regex replacements.