### PR TITLE
Gradle Plugin: Allow using Gradle configuration cache

### DIFF
--- a/reflection-config/build.gradle.kts
+++ b/reflection-config/build.gradle.kts
@@ -25,9 +25,8 @@ gradlePlugin {
   plugins {
     create("reflectionconfig") {
       id = "org.projectnessie.buildsupport.reflectionconfig"
-      displayName = "Reflection-config generator"
-      description =
-        "Generates reflection-config.json configs for all classes for GraalVM native images"
+      displayName = "Reflection-config JSON generator"
+      description = "Generates reflection-config.json configs for GraalVM native images"
       implementationClass = "org.projectnessie.buildtools.reflectionconfig.ReflectionConfigPlugin"
       tags.addAll("projectnessie", "graal", "native")
     }


### PR DESCRIPTION
Gradle's configuration cache aims to avoid costly operations that happen during Gradle's configuration phase, which can be comparabily expensive.

However, using the configuration cache adds some constraints on everything (plugins, custom tasks, build scripts) used in a Gradle build. For example, capturing some types (e.g. `Configuration`, `DependencySet`) is not possible, need to narrow to "more precise" types (like `FileCollection`).