### PR TITLE
Reflection-config: properly clean the output directory

### DIFF
--- a/reflection-config/src/main/kotlin/org/projectnessie/buildtools/reflectionconfig/ReflectionConfigPlugin.kt
+++ b/reflection-config/src/main/kotlin/org/projectnessie/buildtools/reflectionconfig/ReflectionConfigPlugin.kt
@@ -24,7 +24,6 @@ import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.kotlin.dsl.provideDelegate
 
 /** Generates `reflection-config.json` files from compiled classes. */
 @Suppress("unused")


### PR DESCRIPTION
... before generating new content. In case the current contents are "garbage" or the project's group or name have changed.